### PR TITLE
change initialization of GetOrderLines-Request

### DIFF
--- a/lib/pixi_client/requests/get_order_lines.rb
+++ b/lib/pixi_client/requests/get_order_lines.rb
@@ -5,8 +5,15 @@ module PixiClient
 
       # Pixi* documentation says that the pixi order number
       # is mandatory for this requests
-      def initialize(pixi_order_number)
-        self.pixi_order_number = pixi_order_number
+      def initialize(options = {})
+
+        if options[:pixi_order_number]
+          @pixi_order_number = options[:pixi_order_number]
+        elsif options[:message]
+          @message = options[:message]
+        else
+          fail('Parameters must include either pixi_order_number or message-Hash')
+        end
       end
 
       def api_method
@@ -14,6 +21,7 @@ module PixiClient
       end
 
       def message
+        return @message if @message
         { 'OrderNR' => pixi_order_number }
       end
     end

--- a/lib/pixi_client/version.rb
+++ b/lib/pixi_client/version.rb
@@ -1,3 +1,3 @@
 module PixiClient
-  VERSION = "0.0.5"
+  VERSION = "1.0.0"
 end

--- a/spec/lib/pixi_client/requests/get_order_lines_spec.rb
+++ b/spec/lib/pixi_client/requests/get_order_lines_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe PixiClient::Requests::GetOrderLines do
   let(:pixi_order_number) { 1 }
-  subject { PixiClient::Requests::GetOrderLines.new(pixi_order_number) }
+  subject { PixiClient::Requests::GetOrderLines.new(pixi_order_number: pixi_order_number) }
 
   before do
     set_default_config
@@ -16,18 +16,11 @@ describe PixiClient::Requests::GetOrderLines do
     end
   end
 
-  describe 'call behaviour' do
-    let(:expected_response) { double(body: { pixi_get_orderline_response: { pixi_get_orderline_result: sql_row_set_response_mock } }) }
-    let(:double_client) { double }
-
-    before do
-      allow(subject).to receive(:client).and_return(double_client)
-    end
-
+  shared_examples "call_behaviour" do
     it 'should call the client with the appropriate parameters' do
       expect(double_client).to receive(:call)
-      .with(:pixi_get_orderline, attributes: { xmlns: PixiClient.configuration.endpoint }, message: { 'OrderNR' => pixi_order_number})
-      .and_return(expected_response)
+        .with(:pixi_get_orderline, attributes: { xmlns: PixiClient.configuration.endpoint }, message: { 'OrderNR' => pixi_order_number})
+        .and_return(expected_response)
 
       subject.call
     end
@@ -44,4 +37,22 @@ describe PixiClient::Requests::GetOrderLines do
     end
   end
 
+
+  describe 'call behaviour' do
+    let(:expected_response) { double(body: { pixi_get_orderline_response: { pixi_get_orderline_result: sql_row_set_response_mock } }) }
+    let(:double_client) { double }
+
+    before do
+      allow(subject).to receive(:client).and_return(double_client)
+    end
+
+    context 'given pixi_order_number' do
+      it_should_behave_like 'call_behaviour'
+    end
+    context 'given message-hash' do
+      subject { PixiClient::Requests::GetOrderLines.new(message: {'OrderNR' => pixi_order_number}) }
+      it_should_behave_like 'call_behaviour'
+    end
+  end
 end
+


### PR DESCRIPTION
So far initialization only required a pixi_order_number. However there are use cases, where a more diverse query to the pixi API is necessary. For this cases it is now possible to pass the message-hash directly. the message hash contains the parameters used to query pixi.

I bumped version to 1.0. It has been in production use for a while, so it already could have been 1.0. This change breaks backwards-compatibility, so a major version release is in order.