### PR TITLE
Add wdsl to configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ PixiClient.configure do |config|
   config.endpoint = <your_pixi_endpoing_url>
   config.username = <your_pixi_username>
   config.password = <your_pixi_password>
+  config.wsdl     = <path/to/wdsl_document.wsdl>
 end
 ```
 

--- a/lib/pixi_client.rb
+++ b/lib/pixi_client.rb
@@ -1,4 +1,5 @@
 require 'pixi_client/version'
+require 'pixi_client/error'
 require 'pixi_client/configuration'
 require 'pixi_client/response_parser'
 require 'pixi_client/response'

--- a/lib/pixi_client/configuration.rb
+++ b/lib/pixi_client/configuration.rb
@@ -1,5 +1,11 @@
 module PixiClient
   class Configuration
     attr_accessor :endpoint, :username, :password, :wsdl
+
+    def wsdl_document
+      wsdl || endpoint || raise(PixiClient::Error.new("A 'wsdl' or 'endpoint' must be configured"))
+      wsdl ? wsdl : endpoint + '?wsdl'
+    end
+
   end
 end

--- a/lib/pixi_client/configuration.rb
+++ b/lib/pixi_client/configuration.rb
@@ -1,5 +1,5 @@
 module PixiClient
   class Configuration
-    attr_accessor :endpoint, :username, :password
+    attr_accessor :endpoint, :username, :password, :wsdl
   end
 end

--- a/lib/pixi_client/error.rb
+++ b/lib/pixi_client/error.rb
@@ -1,0 +1,4 @@
+module PixiClient
+  class Error < StandardError
+  end
+end

--- a/lib/pixi_client/requests/base.rb
+++ b/lib/pixi_client/requests/base.rb
@@ -15,7 +15,7 @@ module PixiClient
 
       def client
         @client ||= Savon.client(
-          wsdl: PixiClient.configuration.endpoint + '?wsdl',
+          wsdl: PixiClient.configuration.wsdl_document,
           open_timeout: 300,
           read_timeout: 300,
           ssl_verify_mode: :none,

--- a/spec/lib/pixi_client/configuration_spec.rb
+++ b/spec/lib/pixi_client/configuration_spec.rb
@@ -11,6 +11,12 @@ describe PixiClient::Configuration do
       end
     end
 
+    describe '#wsdl' do
+      it 'should be nil' do
+        expect(subject.wsdl).to be_nil
+      end
+    end
+
     describe '#username' do
       it 'should be nil' do
         expect(subject.username).to be_nil
@@ -35,6 +41,13 @@ describe PixiClient::Configuration do
     it 'sets the username' do
       subject.username = 'username'
       expect(subject.username).to eq 'username'
+    end
+  end
+
+  describe '#wsdl=' do
+    it 'sets the wsdl' do
+      subject.wsdl = 'wsdl_set'
+      expect(subject.wsdl).to eq 'wsdl_set'
     end
   end
 

--- a/spec/lib/pixi_client/configuration_spec.rb
+++ b/spec/lib/pixi_client/configuration_spec.rb
@@ -28,12 +28,39 @@ describe PixiClient::Configuration do
         expect(subject.password).to be_nil
       end
     end
+
+    describe '#wsdl_document' do
+      it 'should raise an error' do
+        expect {
+          subject.wsdl_document
+          }.to raise_error(PixiClient::Error, "A 'wsdl' or 'endpoint' must be configured")
+      end
+    end
   end
 
-  describe '#endpoint=' do
-    it 'sets the endpoint' do
-      subject.endpoint = 'endpoint_url'
-      expect(subject.endpoint).to eq 'endpoint_url'
+  describe '#wsdl_document' do
+    context 'when and endpoint is set' do
+      it 'returns the remote wsdl document' do
+        subject.endpoint = 'endpoint_url'
+        subject.wsdl = nil
+        expect(subject.wsdl_document).to eq('endpoint_url?wsdl')
+      end
+    end
+    context 'when and wsdl file is set' do
+      it 'returns the local wsdl document' do
+        subject.endpoint = nil
+        subject.wsdl = 'path/to/endpoint.xml'
+        expect(subject.wsdl_document).to eq('path/to/endpoint.xml')
+      end
+    end
+    context 'when no wsdl or file is set' do
+      it 'raises an error' do
+        subject.endpoint = nil
+        subject.wsdl = nil
+        expect {
+          subject.wsdl_document
+          }.to raise_error(PixiClient::Error, "A 'wsdl' or 'endpoint' must be configured")
+      end
     end
   end
 

--- a/spec/lib/pixi_client/error_spec.rb
+++ b/spec/lib/pixi_client/error_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe PixiClient::Error do
+
+  subject { PixiClient::Error.new }
+
+  it 'should accept a message' do
+    begin
+      raise PixiClient::Error.new('Something happend')
+    rescue => e
+      expect(e.class).to eq(PixiClient::Error)
+      expect(e.message).to eq('Something happend')
+    end
+  end
+end

--- a/spec/lib/pixi_client_spec.rb
+++ b/spec/lib/pixi_client_spec.rb
@@ -6,6 +6,7 @@ describe PixiClient do
       configuration.endpoint = 'endpoint'
       configuration.username = 'username'
       configuration.password = 'random-password'
+      configuration.wsdl     = 'some/path/somewhere.wsdl'
     end
   end
 
@@ -14,6 +15,7 @@ describe PixiClient do
       expect(PixiClient.configuration.endpoint).to eq 'endpoint'
       expect(PixiClient.configuration.username).to eq 'username'
       expect(PixiClient.configuration.password).to eq 'random-password'
+      expect(PixiClient.configuration.wsdl).to eq 'some/path/somewhere.wsdl'
     end
   end
 end


### PR DESCRIPTION
Created the method 'wsdl_document'.

When the pixi_client has only the config for the endpoint but not a 'wsdl', use the remote wsdl document from the endpoint. When instead a path to a local 'wsdl' is given, use it. 

The path to the local 'wsdl' must be absolute and must point to a valid document.