### PR TITLE
Add rake task to download wsdl

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Or install it yourself as:
 #### Rails (with cached wsdl document)
 
 
-run ```bundle exec rake pixi_client:download_wsdl``` in your Rails App root.
+run ```bundle exec rake pixi_client:download_wsdl``` in your Rails app root and add the following initializer to the project.
 
 ```ruby
 PixiClient.configure do |config|
@@ -62,7 +62,7 @@ end
 
 #### Rails (with remote wsdl document)
 
-If you don't want to cache the ```wsdl``` you can omit the ```wsdl``` variable in the configuration. So the gem will download the wdsl document at each request and your configuration will look like:
+If you don't want to cache the ```wsdl``` you can omit that variable in the initializer. The gem will then download the wdsl document at each request and your configuration will look like:
 
 ```ruby
 PixiClient.configure do |config|

--- a/README.md
+++ b/README.md
@@ -46,18 +46,32 @@ Or install it yourself as:
 
 ### Configuration
 
-#### Rails
+#### Rails (with cached wsdl document)
 
-config/initializers/pixi_client.rb
+
+run ```bundle exec rake pixi_client:download_wsdl``` in your Rails App root.
 
 ```ruby
 PixiClient.configure do |config|
   config.endpoint = <your_pixi_endpoing_url>
   config.username = <your_pixi_username>
   config.password = <your_pixi_password>
-  config.wsdl     = <path/to/wdsl_document.wsdl>
+  config.wsdl     = "#{Rails.root}/config/pixi_client.wsdl"
 end
 ```
+
+#### Rails (with remote wsdl document)
+
+If you don't want to cache the ```wsdl``` you can omit the ```wsdl``` variable in the configuration. So the gem will download the wdsl document at each request and your configuration will look like:
+
+```ruby
+PixiClient.configure do |config|
+  config.endpoint = <your_pixi_endpoing_url>
+  config.username = <your_pixi_username>
+  config.password = <your_pixi_password>
+end
+```
+
 
 ### Example of usage
 

--- a/lib/pixi_client.rb
+++ b/lib/pixi_client.rb
@@ -4,6 +4,7 @@ require 'pixi_client/configuration'
 require 'pixi_client/response_parser'
 require 'pixi_client/response'
 require 'pixi_client/requests'
+require 'pixi_client/railtie' if defined?(Rails)
 
 module PixiClient
   class << self

--- a/lib/pixi_client/railtie.rb
+++ b/lib/pixi_client/railtie.rb
@@ -1,0 +1,11 @@
+require 'rails'
+
+module PixiClientRailtie
+  class Railtie < Rails::Railtie
+    railtie_name :pixi_client
+
+    rake_tasks do
+      load 'tasks/pixi_client.rake'
+    end
+  end
+end

--- a/lib/tasks/pixi_client.rake
+++ b/lib/tasks/pixi_client.rake
@@ -1,7 +1,19 @@
+require 'open-uri'
+require 'openssl'
+
 namespace :pixi_client do
-  desc 'Create .example file'
+  desc 'Create .wsdl file'
   task :download_wsdl do
-    touch '.example'
+    OpenSSL::SSL::VERIFY_PEER = OpenSSL::SSL::VERIFY_NONE
+    config = PixiClient.configuration
+    File.open('config/pixi_client.wsdl', "wb") do |wsdl_file|
+      # the following "open" is provided by open-uri
+      open(config.wsdl_document,
+        http_basic_authentication: [config.username, config.password]) do |document|
+          wsdl_file.write(document)
+          puts 'file downloaded in config/pixi_client.wsdl'
+      end
+    end
   end
 
   task :install => [:download_wsdl] do

--- a/lib/tasks/pixi_client.rake
+++ b/lib/tasks/pixi_client.rake
@@ -1,0 +1,9 @@
+namespace :pixi_client do
+  desc 'Create .example file'
+  task :download_wsdl do
+    touch '.example'
+  end
+
+  task :install => [:download_wsdl] do
+  end
+end

--- a/lib/tasks/pixi_client.rake
+++ b/lib/tasks/pixi_client.rake
@@ -2,18 +2,21 @@ require 'open-uri'
 require 'openssl'
 
 namespace :pixi_client do
-  desc 'Create .wsdl file'
+  desc 'Create the file config/pixi_client.wsdl'
   task :download_wsdl do
-    OpenSSL::SSL::VERIFY_PEER = OpenSSL::SSL::VERIFY_NONE
-    config = PixiClient.configuration
+    config = YAML.load_file(File.join([Rails.root, 'config', 'pixi.yml']))[Rails.env]
+
+    OpenSSL::SSL::VERIFY_PEER = OpenSSL::SSL::VERIFY_NONE # needed due to the context
+
     File.open('config/pixi_client.wsdl', "wb") do |wsdl_file|
       # the following "open" is provided by open-uri
-      open(config.wsdl_document,
-        http_basic_authentication: [config.username, config.password]) do |document|
-          wsdl_file.write(document)
+      open(config['url'] + '?wsdl',
+        http_basic_authentication: [config['username'], config['password']]) do |document|
+          wsdl_file.write(document.read)
           puts 'file downloaded in config/pixi_client.wsdl'
       end
     end
+
   end
 
   task :install => [:download_wsdl] do


### PR DESCRIPTION
The rake task requires Rails and generates a local wdsl document in ```config/pixi_client.wsdl```. 

run ```bundle exec rake pixi_client:download_wsdl``` in your Rails app root and add the following initializer to the project.

```ruby
PixiClient.configure do |config|
  config.endpoint = <your_pixi_endpoing_url>
  config.username = <your_pixi_username>
  config.password = <your_pixi_password>
  config.wsdl     = "#{Rails.root}/config/pixi_client.wsdl"
end
```